### PR TITLE
Refined Example

### DIFF
--- a/org.wso2.carbon.game.consumer/pom.xml
+++ b/org.wso2.carbon.game.consumer/pom.xml
@@ -1,74 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>game-manager</artifactId>
-        <groupId>org.wso2.carbon</groupId>
-        <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>game-manager</artifactId>
+		<groupId>org.wso2.carbon</groupId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>org.wso2.carbon.game.consumer</artifactId>
-    <packaging>bundle</packaging>
-    <name>WSO2 Carbon-Game Consumer</name>
+	<artifactId>org.wso2.carbon.game.consumer</artifactId>
+	<packaging>jar</packaging>
+	<name>WSO2 Carbon-Game Consumer</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.artifactId}</Bundle-Name>
-                        <private-package>org.wso2.carbon.game.consumer.internal</private-package>
-                        <Export-Package>
-                            !org.wso2.carbon.game.consumer.internal,
-                            org.wso2.carbon.game.consumer.*
-                        </Export-Package>
-                        <Import-Package>
-                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
-                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
-                            org.wso2.carbon.game.producer.*; version="${project.version}",
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.osgi</groupId>
-            <artifactId>org.eclipse.osgi.services</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.osgi</groupId>
-            <artifactId>org.eclipse.osgi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.game.producer</artifactId>
-        </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>org.wso2.carbon</groupId>
+			<artifactId>org.wso2.carbon.game.producer</artifactId>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/org.wso2.carbon.game.consumer/src/main/java/org/wso2/carbon/game/consumer/GameConsumer.java
+++ b/org.wso2.carbon.game.consumer/src/main/java/org/wso2/carbon/game/consumer/GameConsumer.java
@@ -1,11 +1,27 @@
 package org.wso2.carbon.game.consumer;
 
-import org.wso2.carbon.game.consumer.internal.GameConsumerDataHolder;
+import java.util.logging.Logger;
 
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.wso2.carbon.game.producer.GameProducer;
+
+@Component(
+		service = {}, // This is the default if no interface is implemented and therefore actually unnecessary. Thus this is no Service but a Simple component.
+		immediate = true // This is the default for a Component (not a Service), therefore actually unnecessary and it will be activated as soon as all mandatory references are available
+		)
 public class GameConsumer {
 
-    public void getChampionCreated(String championName) {
+	private static final Logger LOGGER = Logger.getLogger(GameConsumer.class.getName());
 
-        GameConsumerDataHolder.getInstance().getGameProducer().createChampion(championName);
+	@Reference // Will be mandatory by default, as this is a field
+	GameProducer producer;
+	
+    @Activate
+    protected void activate(ComponentContext context) {
+        LOGGER.info("Game consumer Component is activated");
+        producer.createChampion("Zed");
     }
 }

--- a/org.wso2.carbon.game.producer/pom.xml
+++ b/org.wso2.carbon.game.producer/pom.xml
@@ -1,69 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>game-manager</artifactId>
-        <groupId>org.wso2.carbon</groupId>
-        <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>game-manager</artifactId>
+		<groupId>org.wso2.carbon</groupId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>org.wso2.carbon.game.producer</artifactId>
-    <packaging>bundle</packaging>
-    <name>WSO2 Carbon-Game Producer</name>
+	<artifactId>org.wso2.carbon.game.producer</artifactId>
+	<packaging>jar</packaging>
+	<name>WSO2 Carbon-Game Producer</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.artifactId}</Bundle-Name>
-                        <private-package>org.wso2.carbon.game.producer.internal</private-package>
-                        <Export-Package>
-                            !org.wso2.carbon.game.producer.internal,
-                            org.wso2.carbon.game.producer.*
-                        </Export-Package>
-                        <Import-Package>
-                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
-                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.osgi</groupId>
-            <artifactId>org.eclipse.osgi.services</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.osgi</groupId>
-            <artifactId>org.eclipse.osgi</artifactId>
-        </dependency>
-    </dependencies>
-
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/org.wso2.carbon.game.producer/src/main/java/org/wso2/carbon/game/producer/internal/GameProducerImpl.java
+++ b/org.wso2.carbon.game.producer/src/main/java/org/wso2/carbon/game/producer/internal/GameProducerImpl.java
@@ -1,42 +1,26 @@
-package org.wso2.carbon.game.producer;
+package org.wso2.carbon.game.producer.internal;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.wso2.carbon.game.producer.GameProducer;
 import org.wso2.carbon.game.producer.model.Champion;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
+@Component(scope = ServiceScope.SINGLETON)
 public class GameProducerImpl implements GameProducer {
 
     private static final Logger LOGGER = Logger.getLogger(GameProducerImpl.class.getName());
-    private static volatile GameProducerImpl gameProducer;
     private static List<Champion> champions = new ArrayList<Champion>();
 
-    private GameProducerImpl() {
-
-    }
-
-    // Use singleton design pattern to create single instance.
-    public static GameProducerImpl getInstance() {
-
-        if (gameProducer == null) {
-            synchronized (GameProducerImpl.class) {
-                if (gameProducer == null) {
-                    gameProducer = new GameProducerImpl();
-                }
-            }
-        }
-        return gameProducer;
-    }
-
     public void createChampion(String championName) {
-
         Champion champion = new Champion(championName);
         LOGGER.info("Created a Champion:" + champion.getChampionName());
     }
 
     public List<Champion> listChampions() {
-
         return champions;
     }
 }

--- a/org.wso2.carbon.game.producer/src/main/java/org/wso2/carbon/game/producer/model/package-info.java
+++ b/org.wso2.carbon.game.producer/src/main/java/org/wso2/carbon/game/producer/model/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.bundle.Export
+package org.wso2.carbon.game.producer.model;

--- a/org.wso2.carbon.game.producer/src/main/java/org/wso2/carbon/game/producer/package-info.java
+++ b/org.wso2.carbon.game.producer/src/main/java/org/wso2/carbon/game/producer/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.bundle.Export
+package org.wso2.carbon.game.producer;

--- a/pom.xml
+++ b/pom.xml
@@ -1,119 +1,125 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.wso2.carbon</groupId>
-    <artifactId>game-manager</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <modules>
-        <module>org.wso2.carbon.game.producer</module>
-        <module>org.wso2.carbon.game.consumer</module>
-    </modules>
+	<groupId>org.wso2.carbon</groupId>
+	<artifactId>game-manager</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<modules>
+		<module>org.wso2.carbon.game.producer</module>
+		<module>org.wso2.carbon.game.consumer</module>
+	</modules>
 
-    <packaging>pom</packaging>
-    <name>WSO2 Carbon-Game Manager</name>
+	<packaging>pom</packaging>
+	<name>WSO2 Carbon-Game Manager</name>
 
-    <repositories>
-        <!-- Below configuration is used to download the relevant jars and plugins from the remote maven repositories -->
-        <repository>
-            <id>wso2-nexus</id>
-            <name>WSO2 internal Repository</name>
-            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
+	<repositories>
+		<!-- Below configuration is used to download the relevant jars and plugins 
+			from the remote maven repositories -->
+		<repository>
+			<id>wso2-nexus</id>
+			<name>WSO2 internal Repository</name>
+			<url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>daily</updatePolicy>
+				<checksumPolicy>ignore</checksumPolicy>
+			</releases>
+		</repository>
 
-        <repository>
-            <id>wso2.releases</id>
-            <name>WSO2 internal Repository</name>
-            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
+		<repository>
+			<id>wso2.releases</id>
+			<name>WSO2 internal Repository</name>
+			<url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>daily</updatePolicy>
+				<checksumPolicy>ignore</checksumPolicy>
+			</releases>
+		</repository>
 
-        <repository>
-            <id>wso2.snapshots</id>
-            <name>WSO2 Snapshot Repository</name>
-            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-scr-plugin</artifactId>
-                    <version>${maven.scr.plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>generate-scr-scrdescriptor</id>
-                            <goals>
-                                <goal>scr</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>${maven.bundle.plugin.version}</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <obrRepository>NONE</obrRepository>
-                        <instructions></instructions>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
-                <version>${apache.felix.scr.ds.annotations.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.osgi</groupId>
-                <artifactId>org.eclipse.osgi.services</artifactId>
-                <version>${equinox.osgi.services.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.osgi</groupId>
-                <artifactId>org.eclipse.osgi</artifactId>
-                <version>${eclipse.osgi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.game.producer</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+		<repository>
+			<id>wso2.snapshots</id>
+			<name>WSO2 Snapshot Repository</name>
+			<url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>daily</updatePolicy>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+	</repositories>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
+					<version>${bnd.plugin.version}</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>bnd-process</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>osgi.core</artifactId>
+				<version>${osgi.core.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>osgi.cmpn</artifactId>
+				<version>${osgi.cmpn.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>osgi.annotation</artifactId>
+				<version>${osgi.annotation.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.wso2.carbon</groupId>
+				<artifactId>org.wso2.carbon.game.producer</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-    <properties>
-        <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
-        <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
-        <equinox.osgi.services.version>3.3.100.v20130513-1956</equinox.osgi.services.version>
-        <apache.felix.scr.ds.annotations.version>1.2.8</apache.felix.scr.ds.annotations.version>
-        <eclipse.osgi.version>3.9.1.v20130814-1242</eclipse.osgi.version>
-        <maven.scr.plugin.version>1.24.0</maven.scr.plugin.version>
-        <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-    </properties>
+	<properties>
+		<osgi.core.version>6.0.0</osgi.core.version>
+		<osgi.cmpn.version>6.0.0</osgi.cmpn.version>
+		<osgi.annotation.version>7.0.0</osgi.annotation.version>
+		<bnd.plugin.version>5.3.0</bnd.plugin.version>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.cmpn</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+		</dependency>
+	</dependencies>
 </project>


### PR DESCRIPTION
Dear Maneesha,

yesterday I stumbled upon your "Get Hands dirty with OSGi" post and first and foremost want to thank you. As OSGi Evangelist and Member of the OSGi Working Group I applaud everyone, who helps spread the word about OSGi. 

As OSGi is just a bunch of specifications, we don't have a unified tooling or set of implementations. This has lead in past to a lot of fractured Information that is often outdated or does not represent the recommended method of implementing things. That said, I've taken the liberty to suggest a few changes to your example to make life easier for you or anybody how wants to get started with OSGi and finds your post.

Let me walk you through my changes:

# Tooling

The maven bundle plugin is not a bad choice, if a bit outdated. If you want a easier solution I recommend bnd. It is a brought tool, that has implementations for gradle, maven and its own flavor of workspace. The latest Specifications are always implemented and is maintained actively by the participants of the OSGi Working group. Most OSGi tooling uses bnd or parts of it underneath like the maven bundle plugin does. I migrated your maven setup to the [bnd-maven-plugin](https://github.com/bndtools/bnd/tree/master/maven/bnd-maven-plugin).

The bnd plugin covers most standard use cases and one is rarely required to manually modify its behavior (e.g.  manually mark private packages e.g.). It reads annotations, so you can control Exported Packages via the Annotations made in the package-info.java. 

# Dependencies

It is recommended to write your implementation against the OSGi interfaces. Doing so makes your result portable.  I've seen that the equinox (org.elipse.osgi) and the companion services dependencies you used is rather old. I strongly recommend updating to a newer Version because e.g. Declarative Services improved bigtime since Version 1.4. A lot of the constructs you use will become obsolete (I will explain later in detail) and make your life as a developer much easier.

# Declarative Services

Declarative Services and Components in OSGi are singleton by default if not somehow declared otherwise. Thus your construct with the static INSTANCE will be unnecessary. This pattern is strongly discouraged. DS will take care of the start order of your components. If someone wants to use the static access to your component chances are high, that DS has not initialized it yet. Thus things that work at one point might not work the next time you deploy or start something. This is what happens with a lot of the eclipse bundles, what are depending on start order, because of this pattern.

In its current Version DS also supports field injection. This makes method injection obsolete for most cases. We only use it, if we dynamically want to react to appearing and disappearing services. 

In your example you have registered a service manually as a component started. This is only recommended, if you want to modify the service properties, while the service is registered. As in your example a Component with an interface will automatically become a registered service. 

I'm not sure what bastardiesed version of the org.osgi.service.component.annotations package org.eclipse.osgi.services is providing, but for some reason it is not really the advertised version 1.3. If my Version is not working in your WSO Server I would suggest raising or adding Apache SCR in one of the latest Versions. It should be compatible with the Framework Version you used. 

I hope you see my suggestions as a good natured advise and not as critic of your work. If you have any questions or need help, you can contact me anytime. 

Respectfully,

Jürgen.